### PR TITLE
Backslash replacement with double backslash in netlist_info.json using tb_generator.py

### DIFF
--- a/lib/python3/tb_generator.py
+++ b/lib/python3/tb_generator.py
@@ -83,7 +83,14 @@ def create_folders_and_file():
 
     # Read the JSON file
     with open(port_info_path) as json_file:
-        data = json.load(json_file)
+        # Read the content of the file
+        content = json_file.read()
+
+        # Replace all occurrences of backslash with double backslashes
+        content = content.replace("\\", "\\\\")
+
+        # Parse the corrected JSON content
+        data = json.loads(content)
 
     # Extract topModule
     top_module = data['top']


### PR DESCRIPTION
Error was encountered due to the single backslash (\) characters in the "name" fields of the netlist_info.json content